### PR TITLE
[AAE-2527] Fix publishing of new ADF versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ matrix:
 
     - stage: Release
       name: Release
-      if: (type = push OR type = cron) AND tag IS blank
+      if: type = push AND tag IS blank
       script:
       - ./scripts/publish.sh
 


### PR DESCRIPTION
https://issues.alfresco.com/jira/browse/AAE-2527 
Right now, every time ADF releases a new Beta, it pushes a change in the children apps i.e. the Generator App.

the problem is that this PR automatically releases that version of the generator even though it has not been merged. Because of this, when it's merged to make it part of the repo it tries to publish it again and it fails since that version is already public. That is why we have red builds in the generator. 

 

In order to fix it we need to make sure we only publish each version once.