### PR TITLE
[ADF-5282] Remove Node-sass dependecies

### DIFF
--- a/app/templates/adf-cli-acs-aps-template/package.json
+++ b/app/templates/adf-cli-acs-aps-template/package.json
@@ -75,7 +75,6 @@
     "karma-jasmine-html-reporter": "^0.2.2",
     "protractor": "^5.4.0",
     "puppeteer": "1.17.0",
-    "node-sass": "^4.11.0",
     "ts-node": "~4.1.0",
     "tslib": "^1.9.0",
     "tslint": "5.9.1",

--- a/app/templates/adf-cli-acs-template/package.json
+++ b/app/templates/adf-cli-acs-template/package.json
@@ -71,7 +71,6 @@
     "karma-coverage-istanbul-reporter": "~2.0.0",
     "karma-jasmine": "~1.1.1",
     "karma-jasmine-html-reporter": "^0.2.2",
-    "node-sass": "^4.13.0",
     "protractor": "^5.4.0",
     "puppeteer": "1.17.0",
     "ts-node": "~4.1.0",

--- a/app/templates/adf-cli-activiti-acs-template/package.json
+++ b/app/templates/adf-cli-activiti-acs-template/package.json
@@ -75,7 +75,6 @@
     "karma-jasmine-html-reporter": "^0.2.2",
     "protractor": "^5.4.0",
     "puppeteer": "1.17.0",
-    "node-sass": "^4.11.0",
     "ts-node": "~4.1.0",
     "tslib": "^1.9.0",
     "tslint": "5.9.1",

--- a/app/templates/adf-cli-activiti-cloud-acs-template/package.json
+++ b/app/templates/adf-cli-activiti-cloud-acs-template/package.json
@@ -75,7 +75,6 @@
     "karma-jasmine-html-reporter": "^0.2.2",
     "protractor": "^5.4.0",
     "puppeteer": "1.17.0",
-    "node-sass": "^4.11.0",
     "ts-node": "~4.1.0",
     "tslib": "^1.9.0",
     "tslint": "5.9.1",

--- a/app/templates/adf-cli-activiti-cloud-template/package.json
+++ b/app/templates/adf-cli-activiti-cloud-template/package.json
@@ -75,7 +75,6 @@
     "karma-jasmine-html-reporter": "^0.2.2",
     "protractor": "^5.4.0",
     "puppeteer": "1.17.0",
-    "node-sass": "^4.11.0",
     "ts-node": "~4.1.0",
     "tslib": "^1.9.0",
     "tslint": "5.9.1",

--- a/app/templates/adf-cli-activiti-template/package.json
+++ b/app/templates/adf-cli-activiti-template/package.json
@@ -75,7 +75,6 @@
     "karma-jasmine-html-reporter": "^0.2.2",
     "protractor": "^5.4.0",
     "puppeteer": "1.17.0",
-    "node-sass": "^4.11.0",
     "ts-node": "~4.1.0",
     "tslib": "^1.9.0",
     "tslint": "5.9.1",

--- a/app/templates/adf-cli-aps-template/package.json
+++ b/app/templates/adf-cli-aps-template/package.json
@@ -75,7 +75,6 @@
     "karma-jasmine-html-reporter": "^0.2.2",
     "protractor": "^5.4.0",
     "puppeteer": "1.17.0",
-    "node-sass": "^4.11.0",
     "ts-node": "~4.1.0",
     "tslib": "^1.9.0",
     "tslint": "5.9.1",

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -40,6 +40,9 @@ exports.config = {
     chromeOptions: {
       binary: require('puppeteer').executablePath(),
       args: args_options
+    },
+    loggingPrefs: {
+      browser: 'SEVERE' // "OFF", "SEVERE", "WARNING", "INFO", "CONFIG", "FINE", "FINER", "FINEST", "ALL".
     }
   },
 


### PR DESCRIPTION
https://issues.alfresco.com/jira/browse/ADF-5282

As LisSass is getting deprecated we need to remove it from our generator templates. Node-sass is no longer needed as Angular 10 already comes with a built-in scss interpreter.