### PR TITLE
Default app.config to use Basic authentication

### DIFF
--- a/app/templates/adf-cli-acs-aps-template/src/app.config.json
+++ b/app/templates/adf-cli-acs-aps-template/src/app.config.json
@@ -7,7 +7,7 @@
   "application": {
     "name": "Alfresco ADF Application"
   },
-  "authType": "OAUTH",
+  "authType": "BASIC",
   "oauth2": {
     "host": "{protocol}//{hostname}{:port}/auth/realms/alfresco",
     "clientId": "alfresco",

--- a/app/templates/adf-cli-acs-template/src/app.config.json
+++ b/app/templates/adf-cli-acs-template/src/app.config.json
@@ -6,7 +6,7 @@
   "application": {
     "name": "Alfresco ADF Application"
   },
-  "authType": "OAUTH",
+  "authType": "BASIC",
   "oauth2": {
     "host": "{protocol}//{hostname}{:port}/auth/realms/alfresco",
     "clientId": "alfresco",

--- a/app/templates/adf-cli-activiti-acs-template/src/app.config.json
+++ b/app/templates/adf-cli-activiti-acs-template/src/app.config.json
@@ -7,7 +7,7 @@
   "application": {
     "name": "Alfresco ADF Application"
   },
-  "authType": "OAUTH",
+  "authType": "BASIC",
   "oauth2": {
     "host": "{protocol}//{hostname}{:port}/auth/realms/alfresco",
     "clientId": "alfresco",

--- a/app/templates/adf-cli-activiti-cloud-acs-template/src/app.config.json
+++ b/app/templates/adf-cli-activiti-cloud-acs-template/src/app.config.json
@@ -6,7 +6,7 @@
   "application": {
     "name": "Alfresco ADF Application"
   },
-  "authType": "OAUTH",
+  "authType": "BASIC",
   "oauth2": {
     "host": "{protocol}//{hostname}{:port}/auth/realms/alfresco",
     "clientId": "alfresco",

--- a/app/templates/adf-cli-activiti-cloud-template/src/app.config.json
+++ b/app/templates/adf-cli-activiti-cloud-template/src/app.config.json
@@ -6,7 +6,7 @@
   "application": {
     "name": "Alfresco ADF Application"
   },
-  "authType": "OAUTH",
+  "authType": "BASIC",
   "oauth2": {
     "host": "{protocol}//{hostname}{:port}/auth/realms/alfresco",
     "clientId": "alfresco",

--- a/app/templates/adf-cli-activiti-template/src/app.config.json
+++ b/app/templates/adf-cli-activiti-template/src/app.config.json
@@ -6,7 +6,7 @@
   "application": {
     "name": "Alfresco ADF Application"
   },
-  "authType": "OAUTH",
+  "authType": "BASIC",
   "oauth2": {
     "host": "{protocol}//{hostname}{:port}/auth/realms/alfresco",
     "clientId": "alfresco",

--- a/app/templates/adf-cli-aps-template/src/app.config.json
+++ b/app/templates/adf-cli-aps-template/src/app.config.json
@@ -6,7 +6,7 @@
   "application": {
     "name": "Alfresco ADF Application"
   },
-  "authType": "OAUTH",
+  "authType": "BASIC",
   "oauth2": {
     "host": "{protocol}//{hostname}{:port}/auth/realms/alfresco",
     "clientId": "alfresco",


### PR DESCRIPTION
`OAUTH` is configured by default in the app templates. This causes anyone standing up fresh Alfresco Content Services containers (14 day trial or Community) to experience an infinite loop when they attempt to launch the Yoman generated Angular application. By default app templates should use `BASIC`

> [1/7/2021 10:38 AM] Eugenio Romano
    I have in my todo list to make it the default option in the generator

