### PR TITLE
core-js@<3 is no longer maintained and not recommended for usage

### DIFF
--- a/app/templates/adf-cli-acs-aps-template/package.json
+++ b/app/templates/adf-cli-acs-aps-template/package.json
@@ -39,7 +39,7 @@
     "@ngx-translate/core": "^13.0.0",
     "chart.js": "2.5.0",
     "classlist.js": "1.1.20150312",
-    "core-js": "^2.5.4",
+    "core-js": "^3.8.3",
     "custom-event-polyfill": "0.3.0",
     "hammerjs": "2.0.8",
     "minimatch-browser": "1.0.0",

--- a/app/templates/adf-cli-acs-template/package.json
+++ b/app/templates/adf-cli-acs-template/package.json
@@ -38,7 +38,7 @@
     "@ngx-translate/core": "^13.0.0",
     "chart.js": "2.5.0",
     "classlist.js": "1.1.20150312",
-    "core-js": "^2.5.4",
+    "core-js": "^3.8.3",
     "custom-event-polyfill": "0.3.0",
     "hammerjs": "2.0.8",
     "minimatch-browser": "1.0.0",

--- a/app/templates/adf-cli-activiti-acs-template/package.json
+++ b/app/templates/adf-cli-activiti-acs-template/package.json
@@ -39,7 +39,7 @@
     "@ngx-translate/core": "^13.0.0",
     "chart.js": "2.5.0",
     "classlist.js": "1.1.20150312",
-    "core-js": "^2.5.4",
+    "core-js": "^3.8.3",
     "custom-event-polyfill": "0.3.0",
     "hammerjs": "2.0.8",
     "minimatch-browser": "1.0.0",

--- a/app/templates/adf-cli-activiti-cloud-acs-template/package.json
+++ b/app/templates/adf-cli-activiti-cloud-acs-template/package.json
@@ -39,7 +39,7 @@
     "@ngx-translate/core": "^13.0.0",
     "chart.js": "2.5.0",
     "classlist.js": "1.1.20150312",
-    "core-js": "^2.5.4",
+    "core-js": "^3.8.3",
     "custom-event-polyfill": "0.3.0",
     "hammerjs": "2.0.8",
     "minimatch-browser": "1.0.0",

--- a/app/templates/adf-cli-activiti-cloud-template/package.json
+++ b/app/templates/adf-cli-activiti-cloud-template/package.json
@@ -39,7 +39,7 @@
     "@ngx-translate/core": "^13.0.0",
     "chart.js": "2.5.0",
     "classlist.js": "1.1.20150312",
-    "core-js": "^2.5.4",
+    "core-js": "^3.8.3",
     "custom-event-polyfill": "0.3.0",
     "hammerjs": "2.0.8",
     "minimatch-browser": "1.0.0",

--- a/app/templates/adf-cli-activiti-template/package.json
+++ b/app/templates/adf-cli-activiti-template/package.json
@@ -39,7 +39,7 @@
     "@ngx-translate/core": "^13.0.0",
     "chart.js": "2.5.0",
     "classlist.js": "1.1.20150312",
-    "core-js": "^2.5.4",
+    "core-js": "^3.8.3",
     "custom-event-polyfill": "0.3.0",
     "hammerjs": "2.0.8",
     "minimatch-browser": "1.0.0",

--- a/app/templates/adf-cli-aps-template/package.json
+++ b/app/templates/adf-cli-aps-template/package.json
@@ -39,7 +39,7 @@
     "@ngx-translate/core": "^13.0.0",
     "chart.js": "2.5.0",
     "classlist.js": "1.1.20150312",
-    "core-js": "^2.5.4",
+    "core-js": "^3.8.3",
     "custom-event-polyfill": "0.3.0",
     "hammerjs": "2.0.8",
     "minimatch-browser": "1.0.0",


### PR DESCRIPTION
Hi.

The old core-js library was being used, so it has been fixed to use the new version.

Dependabot does not seem to be able to detect this, probably because it is listed in the package.json in the Template.